### PR TITLE
Add ModMenu Library Badge on Fabric

### DIFF
--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -32,5 +32,10 @@
   "depends": {
     "fabric-api": "*",
     "minecraft": ">=1.21.5"
+  },
+  "custom": {
+    "modmenu": {
+      "badges": ["library"]
+    }
   }
 }


### PR DESCRIPTION
This tells ModMenu that the mod is a library and so fixes the mod being shown in the menu even when the user wants library mods hidden.