### PR TITLE
Trim the second part of system info

### DIFF
--- a/common/src/main/java/com/teamresourceful/resourcefullib/client/sysinfo/SystemInfo.java
+++ b/common/src/main/java/com/teamresourceful/resourcefullib/client/sysinfo/SystemInfo.java
@@ -37,7 +37,7 @@ public final class SystemInfo {
             builder.append("# ").append(infoBuilder.category()).append("\n");
             for (var info : infoBuilder.info()) {
                 builder.append("[").append(info.getFirst()).append("]")
-                    .append("[").append(info.getSecond()).append("]")
+                    .append("[").append(info.getSecond().trim()).append("]")
                     .append("\n");
             }
             builder.append("\n");


### PR DESCRIPTION
Some vendors like to put `                       ` there so this prevents it

:3